### PR TITLE
docs: add tokenSource documentation for v0.64.0

### DIFF
--- a/content/en/docs/Features/common/authentication.md
+++ b/content/en/docs/Features/common/authentication.md
@@ -22,6 +22,40 @@ auth.token = "abc"
 auth.token = "abc"
 ```
 
+### Loading Token from File
+
+*Added in v0.64.0*
+
+frp supports using `tokenSource` to load authentication tokens from files instead of hardcoding them in configuration files. This feature helps avoid exposing sensitive information directly in configuration files.
+
+#### Configuration
+
+The tokenSource field is mutually exclusive with the token field - you can only use one of them.
+
+**Server configuration example:**
+
+```toml
+# frps.toml
+bindPort = 7000
+auth.tokenSource.type = "file"
+auth.tokenSource.file.path = "/etc/frp/server_token"
+```
+
+**Client configuration example:**
+
+```toml
+# frpc.toml
+auth.tokenSource.type = "file"
+auth.tokenSource.file.path = "/etc/frp/client_token"
+```
+
+#### Important Notes
+
+1. Token files should have appropriate permissions (e.g., 600) to ensure only the user running frp can read them
+2. Tokens in files will have leading and trailing whitespace automatically trimmed
+3. tokenSource is resolved at configuration load time and does not support runtime dynamic reloading
+4. Currently only the `file` type tokenSource is supported
+
 ## OIDC (OpenID Connect) Authentication
 
 OIDC authentication is an open standard-based authentication method that uses OIDC providers for identity verification.

--- a/content/en/docs/Reference/client-configures.md
+++ b/content/en/docs/Reference/client-configures.md
@@ -65,7 +65,8 @@ description: >
 | :--- | :--- | :--- | :--- |
 | method | string | Authentication method. Options are token or oidc, default is token. | No |
 | additionalScopes | []string | Additional scope for authentication information. Options are HeartBeats and NewWorkConns | No |
-| token | string | Effective when method is token. Client needs to set the same value to pass authentication. | No |
+| token | string | Effective when method is token. Client needs to set the same value to pass authentication. Mutually exclusive with tokenSource field. | No |
+| tokenSource | [ValueSource](../common#valuesource) | Configuration for loading token from file. Mutually exclusive with token field. | No |
 | oidc | [AuthOIDCClientConfig](#authoidcclientconfig) | OIDC authentication configuration. | No |
 
 ### AuthOIDCClientConfig

--- a/content/en/docs/Reference/common.md
+++ b/content/en/docs/Reference/common.md
@@ -63,3 +63,16 @@ description: >
 | :--- | :--- | :--- | :--- |
 | name | string | Header name. | Yes |
 | value | string | Header value. | Yes |
+
+### ValueSource
+
+| Field | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| type | string | Data source type, currently only supports "file". | Yes |
+| file | [FileSource](#filesource) | File data source configuration, required when type is "file". | No |
+
+### FileSource
+
+| Field | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| path | string | File path. | Yes |

--- a/content/en/docs/Reference/server-configures.md
+++ b/content/en/docs/Reference/server-configures.md
@@ -41,7 +41,8 @@ description: >
 | :--- | :--- | :--- | :--- |
 | method | string | Authentication method. Options are token or oidc, default is token. | No |
 | additionalScopes | []string | Additional scope for authentication information. Options are HeartBeats and NewWorkConns | No |
-| token | string | Effective when method is token. Client needs to set the same value to pass authentication. | No |
+| token | string | Effective when method is token. Client needs to set the same value to pass authentication. Mutually exclusive with tokenSource field. | No |
+| tokenSource | [ValueSource](../common#valuesource) | Configuration for loading token from file. Mutually exclusive with token field. | No |
 | oidc | [AuthOIDCServerConfig](#authoidcserverconfig) | OIDC authentication configuration. | No |
 
 ### AuthOIDCServerConfig

--- a/content/zh-cn/docs/Features/common/authentication.md
+++ b/content/zh-cn/docs/Features/common/authentication.md
@@ -22,6 +22,40 @@ auth.token = "abc"
 auth.token = "abc"
 ```
 
+### 从文件加载 Token
+
+*Added in v0.64.0*
+
+frp 支持使用 `tokenSource` 从文件中加载认证 token，而不是在配置文件中硬编码。这个功能可以避免在配置文件中直接暴露敏感信息。
+
+#### 配置方式
+
+tokenSource 与 token 字段互斥，只能选择其中一种方式配置。
+
+**服务端配置示例：**
+
+```toml
+# frps.toml
+bindPort = 7000
+auth.tokenSource.type = "file"
+auth.tokenSource.file.path = "/etc/frp/server_token"
+```
+
+**客户端配置示例：**
+
+```toml
+# frpc.toml
+auth.tokenSource.type = "file"
+auth.tokenSource.file.path = "/etc/frp/client_token"
+```
+
+#### 注意事项
+
+1. token 文件应该设置适当的权限（如 600），确保只有运行 frp 的用户可以读取
+2. 文件中的 token 会自动去除首尾空白字符
+3. tokenSource 在配置加载时解析，不支持运行时动态重新加载
+4. 目前仅支持 `file` 类型的 tokenSource
+
 ## OIDC (OpenID Connect) 身份认证
 
 OIDC 身份认证是一种基于开放标准的身份认证方式，它通过使用 OIDC 提供者进行身份验证。

--- a/content/zh-cn/docs/Reference/client-configures.md
+++ b/content/zh-cn/docs/Reference/client-configures.md
@@ -65,7 +65,8 @@ description: >
 | :--- | :--- | :--- | :--- |
 | method | string | 鉴权方式，可选值为 token 或 oidc，默认为 token。 | No |
 | additionalScopes | []string | 鉴权信息附加范围，可选值为 HeartBeats 和 NewWorkConns | No |
-| token | string | 在 method 为 token 时生效，客户端需要设置一样的值才能鉴权通过。 | No |
+| token | string | 在 method 为 token 时生效，客户端需要设置一样的值才能鉴权通过。与 tokenSource 字段互斥。 | No |
+| tokenSource | [ValueSource](../common#valuesource) | 从文件中加载 token 的配置。与 token 字段互斥。 | No |
 | oidc | [AuthOIDCClientConfig](#authoidcclientconfig) | oidc 鉴权配置。| No |
 
 ### AuthOIDCClientConfig

--- a/content/zh-cn/docs/Reference/common.md
+++ b/content/zh-cn/docs/Reference/common.md
@@ -63,3 +63,16 @@ description: >
 | :--- | :--- | :--- | :--- |
 | name | string | Header 名称。 | Yes |
 | value | string | Header 值。 | Yes |
+
+### ValueSource
+
+| Field | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| type | string | 数据源类型，目前仅支持 "file"。 | Yes |
+| file | [FileSource](#filesource) | 文件数据源配置，当 type 为 "file" 时必填。 | No |
+
+### FileSource
+
+| Field | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| path | string | 文件路径。 | Yes |

--- a/content/zh-cn/docs/Reference/server-configures.md
+++ b/content/zh-cn/docs/Reference/server-configures.md
@@ -41,7 +41,8 @@ description: >
 | :--- | :--- | :--- | :--- |
 | method | string | 鉴权方式，可选值为 token 或 oidc，默认为 token。 | No |
 | additionalScopes | []string | 鉴权信息附加范围，可选值为 HeartBeats 和 NewWorkConns | No |
-| token | string | 在 method 为 token 时生效，客户端需要设置一样的值才能鉴权通过。 | No |
+| token | string | 在 method 为 token 时生效，客户端需要设置一样的值才能鉴权通过。与 tokenSource 字段互斥。 | No |
+| tokenSource | [ValueSource](../common#valuesource) | 从文件中加载 token 的配置。与 token 字段互斥。 | No |
 | oidc | [AuthOIDCServerConfig](#authoidcserverconfig) | oidc 鉴权配置。| No |
 
 ### AuthOIDCServerConfig


### PR DESCRIPTION
Add documentation for the new tokenSource feature introduced in v0.64.0:
- Add feature description in authentication docs with usage examples
- Add tokenSource field to server and client configuration references
- Add ValueSource and FileSource data structures to common references
- Support loading authentication tokens from files instead of hardcoding